### PR TITLE
fix: VSCodeWorkspace namer includes rootProject now

### DIFF
--- a/.vscode/Projen Constructs Monorepo.code-workspace
+++ b/.vscode/Projen Constructs Monorepo.code-workspace
@@ -10,67 +10,67 @@
       "path": ".."
     },
     {
-      "name": "(Lib) cspell",
+      "name": "ROOT",
       "path": "../packages/projen-cspell"
     },
     {
-      "name": "(Lib) github-workflows",
+      "name": "ROOT",
       "path": "../packages/projen-github-workflows"
     },
     {
-      "name": "(Lib) node",
+      "name": "ROOT",
       "path": "../packages/projen-node"
     },
     {
-      "name": "(Lib) nvm",
+      "name": "ROOT",
       "path": "../packages/projen-nvm"
     },
     {
-      "name": "(Lib) sonar",
+      "name": "ROOT",
       "path": "../packages/projen-sonar"
     },
     {
-      "name": "(Lib) sst",
+      "name": "ROOT",
       "path": "../packages/projen-sst"
     },
     {
-      "name": "(Lib) typedoc",
+      "name": "ROOT",
       "path": "../packages/projen-typedoc"
     },
     {
-      "name": "(Lib) vscode-workspaces",
+      "name": "ROOT",
       "path": "../packages/projen-vscode-workspaces"
     },
     {
-      "name": "(Lib) dkershner6-typescript",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-typescript"
     },
     {
-      "name": "(Lib) dkershner6-react",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-react"
     },
     {
-      "name": "(Lib) dkershner6-awscdk-construct-library",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-awscdk-construct-library"
     },
     {
-      "name": "(Lib) dkershner6-github-actions",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-github-actions"
     },
     {
-      "name": "(Lib) dkershner6-awscdk-core",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-awscdk-core"
     },
     {
-      "name": "(Lib) dkershner6-awscdk-app",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-awscdk-app"
     },
     {
-      "name": "(Lib) dkershner6-sst-app",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-sst-app"
     },
     {
-      "name": "(Lib) dkershner6-nx-monorepo",
+      "name": "ROOT",
       "path": "../packages/dkershner6-projen-nx-monorepo"
     }
   ],

--- a/packages/projen-vscode-workspaces/docs/interfaces/VsCodeWorkspacesOptions.md
+++ b/packages/projen-vscode-workspaces/docs/interfaces/VsCodeWorkspacesOptions.md
@@ -60,7 +60,7 @@ ___
 
 ### projectNamer
 
-• `Optional` **projectNamer**: (`project`: `Project`) => `string`
+• `Optional` **projectNamer**: (`rootProject`: `Project`, `project`: `Project`) => `string`
 
 **`Default`**
 
@@ -70,16 +70,21 @@ ___
 
 **`Param`**
 
+The root project definition to use for naming
+
+**`Param`**
+
 The project definition to use for naming
 
 #### Type declaration
 
-▸ (`project`): `string`
+▸ (`rootProject`, `project`): `string`
 
 ##### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `rootProject` | `Project` | The root project definition to use for naming |
 | `project` | `Project` | The project definition to use for naming |
 
 ##### Returns

--- a/packages/projen-vscode-workspaces/src/index.ts
+++ b/packages/projen-vscode-workspaces/src/index.ts
@@ -31,10 +31,11 @@ export interface VsCodeWorkspacesOptions {
     /**
      * @default (project) => project.name
      *
+     * @param rootProject The root project definition to use for naming
      * @param project The project definition to use for naming
      * @returns The name of the project in the context of VSCode Workspaces
      */
-    projectNamer?: (project: Project) => string;
+    projectNamer?: (rootProject: Project, project: Project) => string;
     /**
      * @default ".vscode"
      */
@@ -72,14 +73,14 @@ export class VsCodeWorkspaces extends Component {
                 },
                 folders: [
                     {
-                        name: projectNamer(rootProject),
+                        name: projectNamer(rootProject, rootProject),
                         path: path.relative(
                             path.join(rootProject.outdir, workspacesFilePath),
                             rootProject.outdir,
                         ),
                     },
                     ...(rootProject.subprojects?.map((subProject) => ({
-                        name: projectNamer(subProject),
+                        name: projectNamer(rootProject, subProject),
                         path: path.relative(
                             path.join(rootProject.outdir, workspacesFilePath),
                             subProject.outdir,


### PR DESCRIPTION
Fixes #